### PR TITLE
Platform: Java 25 und Paper 26.2 als Build-Basis etablieren

### DIFF
--- a/.github/work-items/41.md
+++ b/.github/work-items/41.md
@@ -1,5 +1,0 @@
-# Prepared work item #41
-
-Reservation marker for the prepared autonomous Draft PR.
-
-This file contains no product behavior. The worker must remove it before setting the PR to READY FOR REVIEW.

--- a/.github/work-items/41.md
+++ b/.github/work-items/41.md
@@ -1,0 +1,5 @@
+# Prepared work item #41
+
+Reservation marker for the prepared autonomous Draft PR.
+
+This file contains no product behavior. The worker must remove it before setting the PR to READY FOR REVIEW.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ permissions:
 
 jobs:
   verify:
-    name: Java 21 / Maven Verify
-    runs-on: ubuntu-latest
+    name: Java 25 / Maven Verify
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       - name: Verify

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,19 +14,19 @@ permissions:
 
 jobs:
   analyze:
-    name: Java CodeQL
-    runs-on: ubuntu-latest
+    name: Java 25 CodeQL
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 20
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       - name: Initialize CodeQL

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ reducing duplicated boilerplate across multiple plugins.
 
 ## Requirements
 
-- Paper 1.21+
-- Java 21+
+- Paper 26.2
+- Java 25+
+
+The current development line is compiled against the pinned stable Paper API build `26.2.build.121-stable`.
 
 ---
 
@@ -85,7 +87,7 @@ dependencies {
 
 <dependency>
     <groupId>com.github.Tebrox</groupId>
-    <artifactId>VertexCore</artifactactId>
+    <artifactId>VertexCore</artifactId>
     <version>v1.0.0</version>
     <scope>provided</scope>
 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,8 @@
     <name>vertexCore</name>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
+        <paper.version>26.2.build.121-stable</paper.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -24,8 +25,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.4-R0.1-SNAPSHOT</version>
+            <version>${paper.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Arbeitsstatus: READY TO MERGE
Worker-ID: vertexcore-platform-20260902-1952
Issue: #41
Branch: `infra/41-java25-paper26-platform`
Basis: `development`
Base-SHA: `70b802623f10cce7c8bfcad690c8460bc9187fd9`
Head-SHA: `6594049d6cc1b885691bfe0fe6ecbd6cf2b2c081`

## Ziel
VertexCore als ersten kontrollierten Compatibility-Slice auf Java 25 und Paper 26.2 ausrichten, ohne fachliche Features oder absichtliche 1.x-API-Breaks einzuführen.

## Nicht-Ziel
- keine neuen VertexCore-Features
- keine Persistenzformatänderung
- keine NexusVault-Codeänderung
- kein unnötiges Refactoring
- noch kein dedizierter Paper-Runtime-Smoke; der folgt in einem getrennten Folgeslice

## Vor Beginn lesen
- `docs/AI_WORKFLOW.md`
- `docs/TESTING.md`
- `docs/MAINTAINER_STATUS.md`
- `pom.xml`
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `README.md`
- Issue #41 vollständig

## Nicht verändern
- fachliche Semantik von Config, Database, Commands, Migration und Queue, soweit nicht zwingend für Paper-26.2-Kompilierbarkeit erforderlich
- öffentliche 1.x-Contracts ohne kompatiblen Übergang
- NexusVault

## Verbindlicher Scope
1. Maven-/Compiler-Toolchain auf Java 25 ausrichten.
2. Paper API auf 26.2 aktualisieren.
3. CI und CodeQL auf Java 25 und `[self-hosted, Linux, X64]` umstellen.
4. Nur durch den Plattformwechsel verursachte Compile-/Testprobleme minimal beheben.
5. direkt betroffene Versionsdokumentation synchronisieren.
6. `.github/work-items/41.md` vor READY FOR REVIEW wieder entfernen.

## Akzeptanzkriterien
- `mvn -B -ntp verify` unter Java 25 erfolgreich
- Kompilierung gegen Paper 26.2 erfolgreich
- CI und CodeQL verwenden Organization Self-Hosted Runner
- bestehende Tests grün
- keine absichtlichen API-Breaks
- alle Paper-26.2-bedingten Quellcodeanpassungen in der Übergabe dokumentiert
- Work-Item-Marker entfernt

## Geändert
- Maven-/Compiler-Ziel auf Java 25 angehoben.
- Paper API auf `26.2.build.121-stable` angehoben.
- CI auf Java 25 und Organization Self-Hosted Runner `[self-hosted, Linux, X64]` umgestellt.
- CodeQL auf Java 25 und Organization Self-Hosted Runner `[self-hosted, Linux, X64]` umgestellt.
- README-Plattformangaben auf Paper 26.2 / Java 25 synchronisiert.
- vorhandenen README-Tippfehler bei `artifactId` korrigiert.
- keine produktiven Java-Quellcodeänderungen erforderlich.

## Betroffene Dateien
- `pom.xml`
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `README.md`

## Architektur-/API-Auswirkungen
- keine fachlichen Architekturänderungen
- keine öffentlichen VertexCore-1.x-API-Breaks

## Persistenz-/Konfigurationsauswirkungen
- keine

## Ausgeführt
- GitHub Actions `Java 25 / Maven Verify` auf finalem Head `6594049d6cc1b885691bfe0fe6ecbd6cf2b2c081` -> erfolgreich
- GitHub Actions `Java 25 CodeQL` auf finalem Head `6594049d6cc1b885691bfe0fe6ecbd6cf2b2c081` -> erfolgreich
- Kompilierung gegen Paper `26.2.build.121-stable` im Maven-Verify -> erfolgreich

## Nicht ausgeführt
- dedizierter Paper-26.2-Runtime-Smoke -> bewusst separater Folge-Slice #43
- NexusVault Consumer Compatibility Gate -> bewusst separater Folge-Slice #44 nach #43

## Bekannte Probleme / offene Punkte
- keine für diesen Scope

## Besonders kritisch für Review
- `pom.xml`
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- Runner-/Java-25-Umstellung

## Fresh Maintainer Review
- aktueller `development`-Head: `0eaf7fcd182cf7b7ed597bcf37577e2e871b2325`
- PR-Head unverändert: `6594049d6cc1b885691bfe0fe6ecbd6cf2b2c081`
- PR mergeable, finaler Scope sauber
- Development-Drift seit Base betrifft Autopilot-/Bridge-Dokumentation bzw. separate Workflows und erzeugt keinen Scope-Konflikt
- CI und CodeQL auf exakt dem PR-Head grün
- keine offenen Review-Threads
- Ergebnis: READY TO MERGE

## Übergabe
Fresh Review erfolgreich. Gemäß `docs/AUTONOMOUS_MODE.md` wird in diesem Zustandsübergang noch nicht gemergt; der Merge darf erst in einem späteren frischen Lauf nach erneutem Recheck erfolgen.