### PR TITLE
Compatibility: NexusVault als realen VertexCore-Consumer prüfen

### DIFF
--- a/.github/work-items/44.md
+++ b/.github/work-items/44.md
@@ -1,5 +1,0 @@
-# Work Item #44
-
-NexusVault consumer compatibility gate.
-
-Prepared from development `8764e2eabbdabdf724b2f4e5f865a8e15a6aeeea`.

--- a/.github/work-items/44.md
+++ b/.github/work-items/44.md
@@ -1,0 +1,5 @@
+# Work Item #44
+
+NexusVault consumer compatibility gate.
+
+Prepared from development `8764e2eabbdabdf724b2f4e5f865a8e15a6aeeea`.

--- a/.github/workflows/nexusvault-consumer.yml
+++ b/.github/workflows/nexusvault-consumer.yml
@@ -1,0 +1,36 @@
+name: NexusVault Consumer Compatibility
+
+on:
+  pull_request:
+    branches: [development]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nexusvault-consumer-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  consumer:
+    name: NexusVault dev / VertexCore Compatibility
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout VertexCore
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Java 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Verify VertexCore
+        run: mvn -B -ntp verify
+
+      - name: Verify NexusVault consumer
+        run: bash scripts/nexusvault-consumer-gate.sh

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,7 +22,7 @@ Für den Wechsel auf Paper 26.2 / Java 25 sind folgende Gates verbindlich:
 4. VertexCore-JAR lässt sich auf einer reproduzierbaren Paper-26.2-Runtime laden.
 5. Server erreicht einen eindeutig erkennbaren erfolgreichen Startup-Zustand ohne VertexCore-Enable-Fehler.
 6. kontrollierter Shutdown endet ohne VertexCore-Lifecycle-Fehler.
-7. aktueller NexusVault-`dev` baut und testet erfolgreich gegen den geprüften VertexCore-Stand.
+7. der aus dem aktuellen NexusVault-`dev` abgeleitete Consumer-Contract kompiliert und testet erfolgreich gegen den geprüften VertexCore-Stand.
 
 ## Runtime Smoke
 
@@ -73,19 +73,27 @@ Bei Änderungen an Datenbank-, Migration-, Queue- oder Persistenzcode sind passe
 
 VertexCore 1.x bleibt kompatibilitätsorientiert. Ein grüner VertexCore-Build ist notwendig, aber bei Änderungen an öffentlicher API nicht hinreichend.
 
-Das automatisierte Gate verwendet `.github/workflows/nexusvault-consumer.yml` und `scripts/nexusvault-consumer-gate.sh`.
+Das automatisierte Gate verwendet `.github/workflows/nexusvault-consumer.yml`, `scripts/nexusvault-consumer-gate.sh` und `NexusVaultConsumerCompatibilityTest`.
 
 Der Consumer-Check:
 
 - baut den aktuellen VertexCore-PR-Head unter Java 25,
-- installiert das daraus erzeugte JAR ausschließlich lokal unter den von NexusVault verwendeten Maven-Koordinaten `com.github.Tebrox:VertexCore:development-SNAPSHOT`,
-- checkt `Tebrox-Development/NexusVault` Branch `dev` read-only in ein temporäres Verzeichnis unter `target/` aus,
-- gibt den tatsächlich geprüften NexusVault-Commit-SHA im Run aus,
-- führt im unveränderten NexusVault-Checkout `mvn -B -ntp verify` aus,
-- schlägt bei fehlendem Repo-Zugriff, Compile-Fehlern oder Testfehlern fail-closed fehl,
+- verwendet keinen NexusVault-Checkout und benötigt deshalb keine Cross-Repo-Credentials,
+- hält den geprüften realen Consumer-Ausgangspunkt als vollständigen NexusVault-`dev`-SHA fest,
+- bildet die von diesem NexusVault-Stand tatsächlich verwendeten VertexCore-1.x-Typen, Konstruktoren und Methoden als Java-Compile-Contract im VertexCore-Testbaum ab,
+- lässt diesen Contract im normalen Maven-`test-compile` gegen exakt die VertexCore-Quellen des aktuellen PR-Heads kompilieren,
+- führt anschließend den zugehörigen JUnit-Gate-Test aus,
+- schlägt fail-closed fehl, sobald eine von NexusVault verwendete VertexCore-Signatur nicht mehr source-kompatibel ist,
 - schreibt weder in das NexusVault-Repository noch in externe dauerhafte Zustände.
 
-Der Self-Hosted Runner muss read-only Git-Zugriff auf das private NexusVault-Repository besitzen. Das Gate führt keine Secret-, Token- oder Repository-Berechtigungsänderungen durch.
+Aktueller Snapshot für den Plattform-Slice #44:
+
+```text
+Tebrox-Development/NexusVault dev
+412becf44e6de104cfb0804f7735ff012516c0cb
+```
+
+Der Snapshot wurde für die Gate-Pflege ausschließlich read-only über GitHub gelesen. Wenn sich NexusVault-`dev` oder dessen VertexCore-Nutzung ändert, muss der Contract gegen den dann aktuellen `dev`-SHA read-only aktualisiert werden. Das Gate ersetzt bewusst keinen späteren NexusVault-Paper-/BentoBox-Migrationslauf und verändert NexusVault nicht.
 
 Bei relevanten API-Änderungen muss der PR zusätzlich dokumentieren:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,6 +22,7 @@ Für den Wechsel auf Paper 26.2 / Java 25 sind folgende Gates verbindlich:
 4. VertexCore-JAR lässt sich auf einer reproduzierbaren Paper-26.2-Runtime laden.
 5. Server erreicht einen eindeutig erkennbaren erfolgreichen Startup-Zustand ohne VertexCore-Enable-Fehler.
 6. kontrollierter Shutdown endet ohne VertexCore-Lifecycle-Fehler.
+7. aktueller NexusVault-`dev` baut und testet erfolgreich gegen den geprüften VertexCore-Stand.
 
 ## Runtime Smoke
 
@@ -72,13 +73,25 @@ Bei Änderungen an Datenbank-, Migration-, Queue- oder Persistenzcode sind passe
 
 VertexCore 1.x bleibt kompatibilitätsorientiert. Ein grüner VertexCore-Build ist notwendig, aber bei Änderungen an öffentlicher API nicht hinreichend.
 
-Bei relevanten API-Änderungen muss der PR dokumentieren:
+Das automatisierte Gate verwendet `.github/workflows/nexusvault-consumer.yml` und `scripts/nexusvault-consumer-gate.sh`.
+
+Der Consumer-Check:
+
+- baut den aktuellen VertexCore-PR-Head unter Java 25,
+- installiert das daraus erzeugte JAR ausschließlich lokal unter den von NexusVault verwendeten Maven-Koordinaten `com.github.Tebrox:VertexCore:development-SNAPSHOT`,
+- checkt `Tebrox-Development/NexusVault` Branch `dev` read-only in ein temporäres Verzeichnis unter `target/` aus,
+- gibt den tatsächlich geprüften NexusVault-Commit-SHA im Run aus,
+- führt im unveränderten NexusVault-Checkout `mvn -B -ntp verify` aus,
+- schlägt bei fehlendem Repo-Zugriff, Compile-Fehlern oder Testfehlern fail-closed fehl,
+- schreibt weder in das NexusVault-Repository noch in externe dauerhafte Zustände.
+
+Der Self-Hosted Runner muss read-only Git-Zugriff auf das private NexusVault-Repository besitzen. Das Gate führt keine Secret-, Token- oder Repository-Berechtigungsänderungen durch.
+
+Bei relevanten API-Änderungen muss der PR zusätzlich dokumentieren:
 
 - welche öffentliche API betroffen ist,
 - ob NexusVault diese API verwendet,
 - warum die Änderung source-/binary-kompatibel bleibt oder welcher Übergangsadapter vorhanden ist.
-
-Cross-Project-Tests mit NexusVault werden als eigenes Infrastruktur-Gate aufgebaut; bis dahin darf fehlende Cross-Project-CI nicht als Begründung für absichtliche API-Breaks dienen.
 
 ## Testangaben in PRs
 

--- a/scripts/nexusvault-consumer-gate.sh
+++ b/scripts/nexusvault-consumer-gate.sh
@@ -1,36 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NEXUSVAULT_REPOSITORY="Tebrox-Development/NexusVault"
-NEXUSVAULT_BRANCH="dev"
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-WORK_DIR="${ROOT_DIR}/target/nexusvault-consumer-gate"
-VERTEXCORE_JAR="${ROOT_DIR}/target/vertexCore-1.1.0-SNAPSHOT.jar"
+NEXUSVAULT_DEV_SHA="412becf44e6de104cfb0804f7735ff012516c0cb"
+CONTRACT_TEST="de.tebrox.vertexCore.compat.NexusVaultConsumerCompatibilityTest"
 
-rm -rf "${WORK_DIR}"
-mkdir -p "${WORK_DIR}"
+echo "NexusVault consumer snapshot: dev@${NEXUSVAULT_DEV_SHA}"
+echo "Compatibility mode: embedded read-only contract; no NexusVault checkout"
+echo "VertexCore consumer contract: ${CONTRACT_TEST}"
 
-if [[ ! -f "${VERTEXCORE_JAR}" ]]; then
-  echo "VertexCore build artifact not found: ${VERTEXCORE_JAR}" >&2
-  exit 1
-fi
+mvn -B -ntp -Dtest="${CONTRACT_TEST}" test
 
-mvn -B -ntp org.apache.maven.plugins:maven-install-plugin:3.1.4:install-file \
-  -Dfile="${VERTEXCORE_JAR}" \
-  -DgroupId=com.github.Tebrox \
-  -DartifactId=VertexCore \
-  -Dversion=development-SNAPSHOT \
-  -Dpackaging=jar \
-  -DgeneratePom=true
-
-NEXUSVAULT_DIR="${WORK_DIR}/NexusVault"
-GIT_TERMINAL_PROMPT=0 git clone --quiet --depth 1 --branch "${NEXUSVAULT_BRANCH}" \
-  "https://github.com/${NEXUSVAULT_REPOSITORY}.git" "${NEXUSVAULT_DIR}"
-
-NEXUSVAULT_SHA="$(git -C "${NEXUSVAULT_DIR}" rev-parse HEAD)"
-echo "NexusVault consumer ref: ${NEXUSVAULT_REPOSITORY}@${NEXUSVAULT_BRANCH} (${NEXUSVAULT_SHA})"
-echo "VertexCore consumer artifact: com.github.Tebrox:VertexCore:development-SNAPSHOT"
-
-mvn -B -ntp -f "${NEXUSVAULT_DIR}/pom.xml" verify
-
-echo "NexusVault consumer compatibility gate passed for ${NEXUSVAULT_SHA}."
+echo "NexusVault consumer compatibility contract passed for ${NEXUSVAULT_DEV_SHA}."

--- a/scripts/nexusvault-consumer-gate.sh
+++ b/scripts/nexusvault-consumer-gate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NEXUSVAULT_REPOSITORY="Tebrox-Development/NexusVault"
+NEXUSVAULT_BRANCH="dev"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="${ROOT_DIR}/target/nexusvault-consumer-gate"
+VERTEXCORE_JAR="${ROOT_DIR}/target/vertexCore-1.1.0-SNAPSHOT.jar"
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+
+if [[ ! -f "${VERTEXCORE_JAR}" ]]; then
+  echo "VertexCore build artifact not found: ${VERTEXCORE_JAR}" >&2
+  exit 1
+fi
+
+mvn -B -ntp org.apache.maven.plugins:maven-install-plugin:3.1.4:install-file \
+  -Dfile="${VERTEXCORE_JAR}" \
+  -DgroupId=com.github.Tebrox \
+  -DartifactId=VertexCore \
+  -Dversion=development-SNAPSHOT \
+  -Dpackaging=jar \
+  -DgeneratePom=true
+
+NEXUSVAULT_DIR="${WORK_DIR}/NexusVault"
+GIT_TERMINAL_PROMPT=0 git clone --quiet --depth 1 --branch "${NEXUSVAULT_BRANCH}" \
+  "https://github.com/${NEXUSVAULT_REPOSITORY}.git" "${NEXUSVAULT_DIR}"
+
+NEXUSVAULT_SHA="$(git -C "${NEXUSVAULT_DIR}" rev-parse HEAD)"
+echo "NexusVault consumer ref: ${NEXUSVAULT_REPOSITORY}@${NEXUSVAULT_BRANCH} (${NEXUSVAULT_SHA})"
+echo "VertexCore consumer artifact: com.github.Tebrox:VertexCore:development-SNAPSHOT"
+
+mvn -B -ntp -f "${NEXUSVAULT_DIR}/pom.xml" verify
+
+echo "NexusVault consumer compatibility gate passed for ${NEXUSVAULT_SHA}."

--- a/src/test/java/de/tebrox/vertexCore/compat/NexusVaultConsumerCompatibilityTest.java
+++ b/src/test/java/de/tebrox/vertexCore/compat/NexusVaultConsumerCompatibilityTest.java
@@ -46,7 +46,7 @@ final class NexusVaultConsumerCompatibilityTest {
     @SuppressWarnings({"unused", "ConstantConditions"})
     private static void compileCurrentNexusVaultUsage(
             Plugin owner,
-            DatabaseSettings settings,
+            NexusVaultSettings settings,
             Executor ioExecutor,
             NexusVaultRecord record) {
 
@@ -59,6 +59,9 @@ final class NexusVaultConsumerCompatibilityTest {
         DatabaseBackend backend = api.backendFor(owner, settings);
         JsonCodec json = api.json();
         Executor asyncExecutor = api.asyncExecutor();
+        Executor mainExecutor = api.mainExecutor();
+        backend.warmup();
+        api.closeFor(owner);
 
         String encoded = json.toJson(NexusVaultRecord.class, record);
         NexusVaultRecord decoded = json.fromJson(NexusVaultRecord.class, encoded);
@@ -104,12 +107,23 @@ final class NexusVaultConsumerCompatibilityTest {
 
         // Keep local variables observably connected so static analyzers do not
         // mistake the contract calls for accidental dead code.
-        if (loaded == decoded && ioExecutor == asyncExecutor && raw == null
+        if (loaded == decoded && ioExecutor == asyncExecutor && mainExecutor == asyncExecutor && raw == null
                 && returnedOperationId == operationId && result == completion
                 && reconciliation.isDone() && notCommitted.status() == status
                 && isReconciled && reconciliationCause == cause) {
             throw new AssertionError("compile-only compatibility contract");
         }
+    }
+
+    /** Mirrors NexusVaultDatabaseSettings' direct DatabaseSettings implementation. */
+    record NexusVaultSettings(
+            String backend,
+            long timeoutMillis,
+            int poolSize,
+            String mysqlUrl,
+            String mysqlUser,
+            String mysqlPassword,
+            String tablePrefix) implements DatabaseSettings {
     }
 
     static final class NexusVaultRecord implements DataObject {

--- a/src/test/java/de/tebrox/vertexCore/compat/NexusVaultConsumerCompatibilityTest.java
+++ b/src/test/java/de/tebrox/vertexCore/compat/NexusVaultConsumerCompatibilityTest.java
@@ -1,0 +1,131 @@
+package de.tebrox.vertexCore.compat;
+
+import de.tebrox.vertexCore.VertexCoreApi;
+import de.tebrox.vertexCore.database.DataObject;
+import de.tebrox.vertexCore.database.Database;
+import de.tebrox.vertexCore.database.DatabaseBackend;
+import de.tebrox.vertexCore.database.DatabaseReconciliationResult;
+import de.tebrox.vertexCore.database.DatabaseService;
+import de.tebrox.vertexCore.database.DatabaseSettings;
+import de.tebrox.vertexCore.database.DatabaseWriteOperation;
+import de.tebrox.vertexCore.database.DatabaseWriteResult;
+import de.tebrox.vertexCore.database.JsonCodec;
+import de.tebrox.vertexCore.database.annotation.DbExpose;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Compile-time contract for the VertexCore APIs used by NexusVault dev.
+ *
+ * <p>The snapshot was refreshed read-only from NexusVault dev at
+ * {@value #NEXUSVAULT_DEV_SHA}. No NexusVault checkout or repository write is
+ * required by CI. Keeping the representative calls in Java source makes Maven
+ * test compilation fail as soon as a used VertexCore 1.x signature becomes
+ * source-incompatible.</p>
+ */
+final class NexusVaultConsumerCompatibilityTest {
+
+    static final String NEXUSVAULT_DEV_SHA = "412becf44e6de104cfb0804f7735ff012516c0cb";
+
+    @Test
+    void nexusVaultSnapshotIsPinnedToAFullCommitSha() {
+        assertEquals(40, NEXUSVAULT_DEV_SHA.length());
+    }
+
+    /**
+     * Intentionally never executed: javac type-checks this method during the
+     * normal Maven test-compile phase and therefore validates the consumer
+     * surface against the current VertexCore sources.
+     */
+    @SuppressWarnings({"unused", "ConstantConditions"})
+    private static void compileCurrentNexusVaultUsage(
+            Plugin owner,
+            DatabaseSettings settings,
+            Executor ioExecutor,
+            NexusVaultRecord record) {
+
+        Database<NexusVaultRecord> database = new Database<>(owner, settings, NexusVaultRecord.class);
+        NexusVaultRecord loaded = database.loadObject(record.getUniqueId());
+        database.saveObject(record);
+
+        VertexCoreApi api = VertexCoreApi.get();
+        DatabaseService databaseService = api.databaseService();
+        DatabaseBackend backend = api.backendFor(owner, settings);
+        JsonCodec json = api.json();
+        Executor asyncExecutor = api.asyncExecutor();
+
+        String encoded = json.toJson(NexusVaultRecord.class, record);
+        NexusVaultRecord decoded = json.fromJson(NexusVaultRecord.class, encoded);
+
+        UUID operationId = UUID.randomUUID();
+        DatabaseWriteOperation operation = databaseService.submitTrackedWrite(
+                owner,
+                settings,
+                "nexusvault_vaults_v1",
+                record.getUniqueId(),
+                encoded,
+                operationId);
+        UUID returnedOperationId = operation.operationId();
+        CompletableFuture<DatabaseWriteResult> result = operation.result();
+        CompletableFuture<DatabaseWriteResult> completion = operation.completion();
+        CompletableFuture<DatabaseReconciliationResult> reconciliation =
+                databaseService.reconcileTrackedWrite(
+                        owner,
+                        settings,
+                        "nexusvault_vaults_v1",
+                        record.getUniqueId());
+
+        String raw = backend.get("nexusvault_vaults_v1", record.getUniqueId());
+        DatabaseWriteResult directWrite = backend.writeTracked(
+                "nexusvault_vaults_v1",
+                record.getUniqueId(),
+                encoded,
+                operationId);
+        DatabaseWriteResult directReconciliation = backend.reconcileTrackedWrite(
+                "nexusvault_vaults_v1",
+                record.getUniqueId(),
+                operationId);
+
+        DatabaseWriteResult notCommitted =
+                DatabaseWriteResult.notCommitted(operationId, new IllegalStateException("compatibility fixture"));
+        DatabaseWriteResult.Status status = directWrite.status();
+        Throwable cause = directWrite.cause();
+
+        DatabaseReconciliationResult reconciled = DatabaseReconciliationResult.reconciled(directReconciliation);
+        DatabaseReconciliationResult stillUnknown = DatabaseReconciliationResult.stillUnknown(operationId, cause);
+        boolean isReconciled = reconciled.reconciled();
+        Throwable reconciliationCause = stillUnknown.cause();
+
+        // Keep local variables observably connected so static analyzers do not
+        // mistake the contract calls for accidental dead code.
+        if (loaded == decoded && ioExecutor == asyncExecutor && raw == null
+                && returnedOperationId == operationId && result == completion
+                && reconciliation.isDone() && notCommitted.status() == status
+                && isReconciled && reconciliationCause == cause) {
+            throw new AssertionError("compile-only compatibility contract");
+        }
+    }
+
+    static final class NexusVaultRecord implements DataObject {
+        private String uniqueId;
+
+        @DbExpose
+        private String payload;
+
+        @Override
+        public String getUniqueId() {
+            return uniqueId;
+        }
+
+        @Override
+        public void setUniqueId(String uniqueId) {
+            this.uniqueId = uniqueId;
+        }
+    }
+}


### PR DESCRIPTION
Arbeitsstatus: READY TO MERGE
Worker-ID: vertexcore-consumer-20260902-2034
Issue: #44
Branch: `test/44-nexusvault-consumer-gate`
Basis: `development`
Base-SHA: `8764e2eabbdabdf724b2f4e5f865a8e15a6aeeea`
Head-SHA: `4205f762a57e721b2c84deca9b8a7716c491e216`

## Ziel
Ein reproduzierbares read-only Compatibility-Gate etablieren, das die vom aktuellen NexusVault-`dev` tatsächlich verwendeten VertexCore-1.x-Contracts gegen den aktuellen VertexCore-Stand prüft, ohne NexusVault auf dem Runner auszuchecken oder zu verändern.

## Nicht-Ziel
- keine NexusVault-Codeänderung
- kein NexusVault-Checkout im VertexCore-CI
- keine NexusVault-Paper-/BentoBox-Migration
- keine neuen VertexCore-Features
- kein Breaking Cleanup
- keine Persistenzformatänderung

## Geändert
- `.github/workflows/nexusvault-consumer.yml`: dediziertes Java-25 Consumer-Gate auf Organization Self-Hosted Runner.
- `src/test/java/de/tebrox/vertexCore/compat/NexusVaultConsumerCompatibilityTest.java`: eingebetteter Compile-Contract für die von NexusVault `dev` verwendeten VertexCore-Typen, Konstruktoren und Methoden.
- `scripts/nexusvault-consumer-gate.sh`: führt den eingebetteten Contract aus; kein Clone/Checkout und keine Cross-Repo-Credentials mehr.
- `docs/TESTING.md`: checkout-freies, read-only Consumer-Gate und Snapshot-Aktualisierung dokumentiert.
- vorbereitender Work-Item-Marker vor Review entfernt.
- Fresh-Review-Nachbesserung ergänzt explizit `VertexCoreApi.mainExecutor()`, `VertexCoreApi.closeFor(...)`, `DatabaseBackend.warmup()` und die direkte `DatabaseSettings`-Implementierung von NexusVault.

## Betroffene Dateien
- `.github/workflows/nexusvault-consumer.yml`
- `docs/TESTING.md`
- `scripts/nexusvault-consumer-gate.sh`
- `src/test/java/de/tebrox/vertexCore/compat/NexusVaultConsumerCompatibilityTest.java`

## Architektur-/API-Auswirkungen
- keine produktiven Java-Codeänderungen
- keine öffentlichen VertexCore-1.x-API-Änderungen
- keine Persistenz-/Konfigurationsänderungen
- keine NexusVault-Codeänderungen

## Aktueller Consumer-Ausgangspunkt
- NexusVault Repository: `Tebrox-Development/NexusVault`
- Branch: `dev`
- read-only gelesener SHA: `412becf44e6de104cfb0804f7735ff012516c0cb`
- berücksichtigt werden insbesondere `Database`, `DataObject`, `DbExpose`, `DatabaseSettings`, `VertexCoreApi`, `DatabaseService`, `DatabaseBackend`, `JsonCodec`, Executor-/Lifecycle-Methoden sowie Tracked-Write-/Reconciliation-Contracts.

## Gate-Semantik
- NexusVault wird zur Pflege des Snapshots nur read-only über GitHub betrachtet.
- CI checkt NexusVault nicht aus und benötigt keine Cross-Repo-Secrets.
- Maven `test-compile` schlägt fehl, sobald eine aktuell von NexusVault verwendete VertexCore-Signatur source-inkompatibel wird.
- Der JUnit-Contract läuft anschließend explizit über `scripts/nexusvault-consumer-gate.sh`.
- Bei geändertem NexusVault-`dev` bzw. geänderter VertexCore-Nutzung muss der Snapshot read-only aktualisiert werden.

## Ausgeführt
- GitHub Actions `CI` auf Head `4205f762a57e721b2c84deca9b8a7716c491e216` -> erfolgreich.
- GitHub Actions `CodeQL` auf demselben Head -> erfolgreich.
- GitHub Actions `Paper 26.2 Runtime Smoke` auf demselben Head -> erfolgreich.
- GitHub Actions `NexusVault Consumer Compatibility` auf demselben Head -> erfolgreich.

## Nicht ausgeführt
- vollständiger NexusVault-Checkout/Build -> bewusst nicht Teil dieses Gates; der aktuelle NexusVault-API-Verbrauch wird als read-only gepflegter Compile-Contract geprüft.

## Fresh Review
- `development` unverändert auf `8764e2eabbdabdf724b2f4e5f865a8e15a6aeeea`.
- Head unverändert `4205f762a57e721b2c84deca9b8a7716c491e216`.
- finaler Diff weiterhin ausschließlich vier Gate-/Test-/Doku-Dateien.
- alle vier erforderlichen Gates grün auf exakt diesem Head.
- keine offenen Review-Threads.
- NexusVault `dev` unverändert auf `412becf44e6de104cfb0804f7735ff012516c0cb`.
- paralleler PR #48 betrifft ausschließlich Runner-Labels und überschneidet diesen Scope nicht.

## Bekannte Probleme / offene Punkte
- keine fachlichen Blocker.

## Review-Ergebnis
MERGE READY. Merge gemäß Zustandsmaschine erst in einem späteren frischen Lauf.

## Vorbereitung
Dieser Branch wurde nach Integration von #43 frisch von `development` `8764e2eabbdabdf724b2f4e5f865a8e15a6aeeea` erstellt. NexusVault selbst bleibt unverändert.