### PR TITLE
CI: VertexCore-Jobs auf dedizierten Runner routen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   verify:
     name: Java 25 / Maven Verify
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, vertexcore]
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   analyze:
     name: Java 25 CodeQL
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, vertexcore]
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   runtime-smoke:
     name: Paper 26.2 / VertexCore Runtime Smoke
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, vertexcore]
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
Arbeitsstatus: IN ARBEIT
Worker-ID: vertexcore-runner-label-20260903
Issue: #47
Branch: `infra/47-vertexcore-runner-label`
Basis: `development`
Base-SHA: `8764e2eabbdabdf724b2f4e5f865a8e15a6aeeea`
Head-SHA: `006b27a6aae0c5903278c0bd57bec92795b905d1`

## Ziel
Die bereits integrierten VertexCore-Workflows ausschließlich auf Organization Self-Hosted Runner mit dem zusätzlichen Label `vertexcore` routen.

## Geändert
- `.github/workflows/ci.yml`: `vertexcore` zum `runs-on`-Labelsatz ergänzt.
- `.github/workflows/codeql.yml`: `vertexcore` zum `runs-on`-Labelsatz ergänzt.
- `.github/workflows/runtime-smoke.yml`: `vertexcore` zum `runs-on`-Labelsatz ergänzt.

## Nicht verändert
- keine Java-/Maven-/Paper-Änderungen
- keine NexusVault-Codeänderungen
- aktiver PR #46 / Branch `test/44-nexusvault-consumer-gate` bleibt unangetastet
- keine Runner-/Organization-Konfiguration aus dem Repository heraus

## Architektur-/API-Auswirkungen
Keine.

## Persistenz-/Konfigurationsauswirkungen
Keine.

## Prüfung
- finalen PR-Diff auf ausschließlich drei `runs-on`-Änderungen prüfen
- Actions-Zuweisung auf Runner mit Label `vertexcore` beobachten