### PR TITLE
CI: manuellen Snapshot-Pre-Release-Workflow ergänzen

### DIFF
--- a/.github/work-items/49-snapshot-prerelease.md
+++ b/.github/work-items/49-snapshot-prerelease.md
@@ -1,0 +1,3 @@
+# Work item #49
+
+Temporary marker for the prepared draft PR. Remove before Ready for Review.


### PR DESCRIPTION
Arbeitsstatus: ABGEBROCHEN
Worker-ID: vertexcore-snapshot-20260903-1828
Issue: #49
Branch: `infra/49-snapshot-prerelease`
Basis: `development`
Base-SHA: `4220b7e5430cff1a0d66beab59662c591c39be11`
Head-SHA: `82a71c83d4c2a8b2e8cb027fe07e29441ad286af`

## Abbruchgrund
`workflow_dispatch` kann nur ausgelöst werden, wenn die Workflow-Datei auf dem Repository-Default-Branch liegt. Der Default-Branch ist `master`; deshalb wäre dieser gegen `development` vorbereitete PR nach Merge nicht direkt manuell auslösbar.

## Fortsetzung
Issue #49 wird mit einem minimalen Default-Branch-PR fortgeführt. Der Release-Workflow selbst checkt weiterhin ausschließlich den aktuellen `development`-Stand aus und veröffentlicht daraus den Snapshot.

Keine Release-Ausführung und keine Produktcodeänderung in diesem PR.