### PR TITLE
CI: manuellen Snapshot-Pre-Release-Workflow ergänzen

### DIFF
--- a/.github/work-items/49-snapshot-prerelease.md
+++ b/.github/work-items/49-snapshot-prerelease.md
@@ -1,3 +1,0 @@
-# Work item #49
-
-Temporary marker for the prepared default-branch workflow PR. Remove before Ready for Review.

--- a/.github/work-items/49-snapshot-prerelease.md
+++ b/.github/work-items/49-snapshot-prerelease.md
@@ -1,0 +1,3 @@
+# Work item #49
+
+Temporary marker for the prepared default-branch workflow PR. Remove before Ready for Review.

--- a/.github/workflows/snapshot-prerelease.yml
+++ b/.github/workflows/snapshot-prerelease.yml
@@ -1,0 +1,100 @@
+name: Snapshot Pre-Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: snapshot-prerelease
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build development snapshot
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout current development
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: development
+          fetch-depth: 1
+
+      - name: Set up Java 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Verify
+        run: mvn -B -ntp verify
+
+      - name: Prepare snapshot metadata
+        id: snapshot
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="$(mvn -B -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          if [[ "${VERSION}" != *-SNAPSHOT ]]; then
+            echo "Expected a -SNAPSHOT project version, got: ${VERSION}" >&2
+            exit 1
+          fi
+
+          TARGET_SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="${TARGET_SHA:0:8}"
+          DATE="$(date -u +%Y%m%d)"
+          BASE_VERSION="${VERSION%-SNAPSHOT}"
+          TAG="v${BASE_VERSION}-snapshot.${DATE}.${GITHUB_RUN_NUMBER}"
+          SOURCE_JAR="target/vertexCore-${VERSION}.jar"
+          ASSET_NAME="vertexCore-${VERSION}-${SHORT_SHA}.jar"
+
+          test -f "${SOURCE_JAR}"
+          cp "${SOURCE_JAR}" "${ASSET_NAME}"
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "target_sha=${TARGET_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "short_sha=${SHORT_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "asset_name=${ASSET_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create GitHub pre-release
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ steps.snapshot.outputs.version }}
+          TARGET_SHA: ${{ steps.snapshot.outputs.target_sha }}
+          SHORT_SHA: ${{ steps.snapshot.outputs.short_sha }}
+          TAG: ${{ steps.snapshot.outputs.tag }}
+          ASSET_NAME: ${{ steps.snapshot.outputs.asset_name }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const { data: release } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: process.env.TAG,
+              target_commitish: process.env.TARGET_SHA,
+              name: `VertexCore ${process.env.VERSION} (${process.env.SHORT_SHA})`,
+              body: `Snapshot from development commit ${process.env.TARGET_SHA}.`,
+              draft: false,
+              prerelease: true,
+            });
+
+            const data = fs.readFileSync(process.env.ASSET_NAME);
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              name: process.env.ASSET_NAME,
+              data,
+              headers: {
+                'content-type': 'application/java-archive',
+                'content-length': data.length,
+              },
+            });


### PR DESCRIPTION
Arbeitsstatus: READY FOR REVIEW
Worker-ID: vertexcore-snapshot-20260903-1828
Issue: #49
Branch: `infra/49-snapshot-prerelease-default`
Basis: `master` (Repository-Default-Branch; technisch erforderlich für `workflow_dispatch`)
Base-SHA: `0480c0e2a069a4548a3858a634f3dfe7081c3c7a`
Head-SHA: `2028888b30ee43847515dcd45442dbb568e55662`

## Ziel
Einen manuell auslösbaren GitHub-Actions-Workflow auf dem Default-Branch bereitstellen, der **nicht `master` baut**, sondern den aktuellen `development`-Stand mit Java 25 auscheckt, verifiziert und als GitHub Pre-Release Snapshot inklusive JAR veröffentlicht.

## Technischer Grund für Base `master`
GitHub verarbeitet `workflow_dispatch` nur, wenn die Workflow-Datei auf dem Repository-Default-Branch vorhanden ist. Der Default-Branch dieses Repositories ist `master`.

## Geändert
- `.github/workflows/snapshot-prerelease.yml` neu angelegt.
- einziger Trigger: `workflow_dispatch`
- expliziter Checkout von `development`
- Java 25 + `mvn -B -ntp verify`
- Snapshot-Version wird aus `pom.xml` gelesen und auf `-SNAPSHOT` geprüft
- Tag: `v<version>-snapshot.<UTC-Datum>.<Run-Nummer>`
- Release-Ziel: exakt der tatsächlich ausgecheckte `development`-SHA
- JAR-Asset enthält den kurzen Commit-SHA im Dateinamen
- Release wird über `actions/github-script` als Pre-Release erstellt

## Betroffene Dateien
- `.github/workflows/snapshot-prerelease.yml`

## Architektur-/API-Auswirkungen
Keine.

## Persistenz-/Konfigurationsauswirkungen
Keine.

## Berechtigungen
- nur dieser Workflow: `contents: write`
- ausschließlich automatisches `GITHUB_TOKEN`
- keine neuen Repository-Secrets

## Ausgeführt / geprüft
- finaler PR-Diff: ausschließlich `.github/workflows/snapshot-prerelease.yml`
- Workflow-Inhalt gegen vorhandene Java-25-/Maven-Konventionen geprüft
- `actions/checkout`, `actions/setup-java` und `actions/github-script` auf feste Commit-SHAs gepinnt

## Nicht ausgeführt
- Snapshot-Workflow selbst: bewusst nicht ausgeführt, da er einen echten GitHub Pre-Release erzeugt und erst nach Merge auf den Default-Branch manuell auslösbar ist.

## Bekannte Probleme / offene Punkte
- keine

## Besonders kritisch für Review
- `master` ist hier nur Ablageort des manuellen Workflows; gebaut und veröffentlicht wird immer der zum Startzeitpunkt ausgecheckte `development`-Commit.