### PR TITLE
Compatibility: Java 21+ und Paper 1.21.4–26.2 absichern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   verify:
-    name: Java 25 / Maven Verify
+    name: Java 21 / Maven Verify
     runs-on: [self-hosted, Linux, X64, vertexcore]
     timeout-minutes: 15
 
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Java 25
+      - name: Set up Java 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
-          java-version: '25'
+          java-version: '21'
           cache: maven
 
       - name: Verify

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,7 @@ name: CodeQL
 on:
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [development]
   workflow_dispatch:
@@ -17,8 +18,46 @@ permissions:
   actions: read
 
 jobs:
+  changes:
+    name: Classify CodeQL changes
+    if: github.event_name != 'push'
+    runs-on: [self-hosted, Linux, X64, vertexcore]
+    outputs:
+      relevant: ${{ steps.classify.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Classify
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" || "${EVENT_ACTION}" != "synchronize" || -z "${BEFORE_SHA:-}" ]]; then
+            echo "relevant=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git diff --name-only "${BEFORE_SHA}" "${GITHUB_SHA}" > /tmp/changed-files
+          cat /tmp/changed-files
+
+          if grep -Eq '^((src/)|(pom\.xml$)|(\.github/workflows/codeql\.yml$))' /tmp/changed-files; then
+            echo "relevant=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "relevant=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   analyze:
-    name: Java 25 CodeQL
+    name: Java CodeQL
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.relevant == 'true')
     runs-on: [self-hosted, Linux, X64, vertexcore]
     timeout-minutes: 20
 
@@ -26,11 +65,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Java 25
+      - name: Set up Java 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
-          java-version: '25'
+          java-version: '21'
           cache: maven
 
       - name: Initialize CodeQL

--- a/.github/workflows/nexusvault-consumer.yml
+++ b/.github/workflows/nexusvault-consumer.yml
@@ -3,6 +3,7 @@ name: NexusVault Consumer Compatibility
 on:
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -13,9 +14,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify consumer changes
+    runs-on: [self-hosted, Linux, X64, vertexcore]
+    outputs:
+      relevant: ${{ steps.classify.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Classify
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" || "${EVENT_ACTION}" != "synchronize" || -z "${BEFORE_SHA:-}" ]]; then
+            echo "relevant=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git diff --name-only "${BEFORE_SHA}" "${GITHUB_SHA}" > /tmp/changed-files
+          cat /tmp/changed-files
+
+          if grep -Eq '^((src/main/)|(src/test/java/de/tebrox/vertexCore/compat/)|(pom\.xml$)|(scripts/nexusvault-consumer-gate\.sh$)|(\.github/workflows/nexusvault-consumer\.yml$))' /tmp/changed-files; then
+            echo "relevant=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "relevant=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   consumer:
     name: NexusVault dev / VertexCore Compatibility
-    runs-on: [self-hosted, Linux, X64]
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: [self-hosted, Linux, X64, vertexcore]
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/nexusvault-consumer.yml
+++ b/.github/workflows/nexusvault-consumer.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout VertexCore
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Java 25
+      - name: Set up Java 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
-          java-version: '25'
+          java-version: '21'
           cache: maven
 
       - name: Verify VertexCore

--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -1,4 +1,4 @@
-name: Paper 26.2 Runtime Smoke
+name: Paper Runtime Compatibility
 
 on:
   pull_request:
@@ -10,23 +10,36 @@ permissions:
 
 jobs:
   runtime-smoke:
-    name: Paper 26.2 / VertexCore Runtime Smoke
+    name: Paper ${{ matrix.paper }} / Java ${{ matrix.java }}
     runs-on: [self-hosted, Linux, X64, vertexcore]
-    timeout-minutes: 15
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - paper: '1.21.4'
+            build: '232'
+            java: '21'
+          - paper: '26.2'
+            build: '121'
+            java: '25'
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Set up Java 25
+      - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
         with:
           distribution: temurin
-          java-version: '25'
+          java-version: ${{ matrix.java }}
           cache: maven
 
       - name: Verify
         run: mvn -B -ntp verify
 
       - name: Runtime smoke
+        env:
+          PAPER_VERSION: ${{ matrix.paper }}
+          PAPER_BUILD: ${{ matrix.build }}
         run: bash scripts/runtime-smoke.sh

--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -3,14 +3,52 @@ name: Paper Runtime Compatibility
 on:
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify runtime changes
+    runs-on: [self-hosted, Linux, X64, vertexcore]
+    outputs:
+      relevant: ${{ steps.classify.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Classify
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" || "${EVENT_ACTION}" != "synchronize" || -z "${BEFORE_SHA:-}" ]]; then
+            echo "relevant=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git diff --name-only "${BEFORE_SHA}" "${GITHUB_SHA}" > /tmp/changed-files
+          cat /tmp/changed-files
+
+          if grep -Eq '^((src/main/)|(pom\.xml$)|(scripts/runtime-smoke\.sh$)|(\.github/workflows/runtime-smoke\.yml$))' /tmp/changed-files; then
+            echo "relevant=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "relevant=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   runtime-smoke:
     name: Paper ${{ matrix.paper }} / Java ${{ matrix.java }}
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: [self-hosted, Linux, X64, vertexcore]
     timeout-minutes: 20
     strategy:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,39 +14,44 @@ Der Build muss auf der für den jeweiligen Scope festgelegten Java-Toolchain lau
 
 ## Plattform-Kompatibilität
 
-Für den Wechsel auf Paper 26.2 / Java 25 sind folgende Gates verbindlich:
+VertexCore 1.1.x soll mit einem einzigen Artefakt einen breiteren Paper-Bereich abdecken. Der Build-Contract ist deshalb:
 
-1. Maven-Build mit Java 25 erfolgreich.
-2. Kompilierung gegen Paper API 26.2 erfolgreich.
-3. vorhandene Unit-/Regressionstests erfolgreich.
-4. VertexCore-JAR lässt sich auf einer reproduzierbaren Paper-26.2-Runtime laden.
-5. Server erreicht einen eindeutig erkennbaren erfolgreichen Startup-Zustand ohne VertexCore-Enable-Fehler.
-6. kontrollierter Shutdown endet ohne VertexCore-Lifecycle-Fehler.
-7. der aus dem aktuellen NexusVault-`dev` abgeleitete Consumer-Contract kompiliert und testet erfolgreich gegen den geprüften VertexCore-Stand.
+```text
+Java-Bytecode: 21
+Compile API:   Paper 1.21.4
+Runtime-Gates: Paper 1.21.4 / Java 21 und Paper 26.2 / Java 25
+```
+
+Damit gilt Java 21 als minimale VertexCore-Runtime. Paper-Versionen ab 26.1 benötigen unabhängig davon serverseitig Java 25.
+
+Verbindliche Gates:
+
+1. Maven-Build und Tests auf Java 21 erfolgreich.
+2. Kompilierung gegen die minimale unterstützte Paper API 1.21.4 erfolgreich.
+3. VertexCore-JAR lässt sich auf Paper 1.21.4 mit Java 21 laden und sauber herunterfahren.
+4. Dasselbe JAR lässt sich auf Paper 26.2 mit Java 25 laden und sauber herunterfahren.
+5. der aus dem aktuellen NexusVault-`dev` abgeleitete Consumer-Contract kompiliert und testet erfolgreich auf Java 21 gegen den geprüften VertexCore-Stand.
+
+Zwischenversionen innerhalb des unterstützten Bereichs dürfen keine neueren Paper-APIs voraussetzen als die Compile-Baseline. Die beiden Runtime-Endpunkte bilden das verbindliche CI-Gate; zusätzliche Zwischenstände können bei Bedarf ergänzt werden.
 
 ## Runtime Smoke
 
 Der Runtime-Smoke ist automatisierbar und reproduzierbar und darf keine produktiven Serverdaten, Secrets oder externen Dienste benötigen.
 
-Der Smoke prüft mindestens:
+Die CI verwendet `.github/workflows/runtime-smoke.yml` und `scripts/runtime-smoke.sh`. Der Harness ist über `PAPER_VERSION` und `PAPER_BUILD` parametrierbar.
+
+Aktuell gepinnte Matrix:
 
 ```text
-Paper 26.2 startet
-→ VertexCore wird geladen
-→ VertexCore wird erfolgreich aktiviert
-→ keine uncaught VertexCore-Exception im Startup
-→ Server wird kontrolliert beendet
-→ VertexCore wird sauber deaktiviert
+Paper 1.21.4 Build 232 -> Java 21
+Paper 26.2  Build 121 -> Java 25
 ```
 
-Die CI verwendet dafür `.github/workflows/runtime-smoke.yml` und `scripts/runtime-smoke.sh`.
+Für jeden Matrix-Eintrag wird der aktuelle PR-Head mit `mvn -B -ntp verify` gebaut. Der Harness:
 
-Der Harness:
-
-- baut zuerst den aktuellen PR-Head mit `mvn -B -ntp verify`,
-- lädt ausschließlich den explizit gepinnten stabilen Paper-Stand `26.2` Build `121` über den offiziellen PaperMC-Fill-Service,
-- verwendet das gerade gebaute `target/vertexCore-1.1.0-SNAPSHOT.jar`,
-- startet eine frische temporäre Runtime unter `target/runtime-smoke`,
+- lädt ausschließlich den explizit gepinnten stabilen Paper-Build über den offiziellen PaperMC-Fill-Service,
+- verwendet das gerade gebaute `target/vertexCore-<project.version>.jar`,
+- startet eine frische temporäre Runtime unter `target/runtime-smoke-<paper>-<build>`,
 - wartet fail-closed auf den Paper-Ready-Marker und `VertexCore enabled.`,
 - wertet typische VertexCore-Load-/Enable-Exceptions als Fehler,
 - sendet anschließend kontrolliert `stop`,
@@ -54,8 +59,6 @@ Der Harness:
 - behandelt Disable-/Lifecycle-Exceptions als Fehler.
 
 Der Smoke benötigt Netzwerkzugriff ausschließlich zum offiziellen PaperMC-Download-Service und erzeugt keine dauerhaften externen Zustände.
-
-Sobald fachliche Runtime-Smokes existieren, werden zusätzlich repräsentative Wege für Config, Commands und Persistenz geprüft.
 
 ## Datenbank-/Persistenzänderungen
 
@@ -77,7 +80,7 @@ Das automatisierte Gate verwendet `.github/workflows/nexusvault-consumer.yml`, `
 
 Der Consumer-Check:
 
-- baut den aktuellen VertexCore-PR-Head unter Java 25,
+- baut den aktuellen VertexCore-PR-Head unter Java 21,
 - verwendet keinen NexusVault-Checkout und benötigt deshalb keine Cross-Repo-Credentials,
 - hält den geprüften realen Consumer-Ausgangspunkt als vollständigen NexusVault-`dev`-SHA fest,
 - bildet die von diesem NexusVault-Stand tatsächlich verwendeten VertexCore-1.x-Typen, Konstruktoren und Methoden als Java-Compile-Contract im VertexCore-Testbaum ab,
@@ -86,7 +89,7 @@ Der Consumer-Check:
 - schlägt fail-closed fehl, sobald eine von NexusVault verwendete VertexCore-Signatur nicht mehr source-kompatibel ist,
 - schreibt weder in das NexusVault-Repository noch in externe dauerhafte Zustände.
 
-Aktueller Snapshot für den Plattform-Slice #44:
+Aktueller Snapshot:
 
 ```text
 Tebrox-Development/NexusVault dev

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,32 +14,39 @@ Der Build muss auf der für den jeweiligen Scope festgelegten Java-Toolchain lau
 
 ## Plattform-Kompatibilität
 
-VertexCore 1.1.x wird mit Java-21-Bytecode gebaut und gegen die minimale unterstützte Paper-API 1.21.4 kompiliert. Derselbe VertexCore-Stand wird an beiden Endpunkten des unterstützten Bereichs als Runtime-Smoke geprüft:
+VertexCore 1.1.x wird als Java-21-Bytecode gegen die Paper-API 1.21.4 kompiliert. Der unterstützte Runtime-Vertrag wird an beiden Endpunkten reproduzierbar geprüft:
 
 1. Maven-Build mit Java 21 erfolgreich.
 2. Kompilierung mit `--release 21` gegen Paper API 1.21.4 erfolgreich.
 3. vorhandene Unit-/Regressionstests erfolgreich.
-4. VertexCore-JAR lässt sich auf Paper 1.21.4 mit Java 21 laden.
-5. VertexCore-JAR lässt sich auf Paper 26.2 mit Java 25 laden.
+4. dasselbe VertexCore-JAR lässt sich auf Paper 1.21.4 mit Java 21 laden.
+5. dasselbe VertexCore-JAR lässt sich auf Paper 26.2 mit Java 25 laden.
 6. beide Server erreichen einen eindeutig erkennbaren erfolgreichen Startup-Zustand ohne VertexCore-Enable-Fehler.
 7. kontrollierter Shutdown endet auf beiden Runtime-Endpunkten ohne VertexCore-Lifecycle-Fehler.
-8. der aus dem aktuellen NexusVault-`dev` abgeleitete Consumer-Contract kompiliert und testet unter Java 21 erfolgreich gegen den geprüften VertexCore-Stand.
+8. der aus dem aktuellen NexusVault-`dev` abgeleitete Consumer-Contract kompiliert und testet erfolgreich gegen den geprüften VertexCore-Stand unter Java 21.
+
+Damit gilt für VertexCore selbst Java 21+ als Bytecode-Baseline. Die tatsächlich notwendige Java-Runtime kann zusätzlich von der verwendeten Paper-Version vorgegeben werden.
 
 ## Runtime Smoke
 
 Der Runtime-Smoke ist automatisierbar und reproduzierbar und darf keine produktiven Serverdaten, Secrets oder externen Dienste benötigen.
 
-Die CI verwendet dafür `.github/workflows/runtime-smoke.yml` und `scripts/runtime-smoke.sh` und prüft die Endpunkte:
+Die CI verwendet dafür `.github/workflows/runtime-smoke.yml` und `scripts/runtime-smoke.sh`. Die Matrix prüft mindestens:
 
 ```text
 Paper 1.21.4 Build 232 / Java 21
+→ VertexCore wird geladen und aktiviert
+→ kontrollierter Shutdown ohne VertexCore-Lifecycle-Fehler
+
 Paper 26.2 Build 121 / Java 25
+→ dasselbe VertexCore-JAR wird geladen und aktiviert
+→ kontrollierter Shutdown ohne VertexCore-Lifecycle-Fehler
 ```
 
 Der Harness:
 
-- verwendet dasselbe mit `--release 21` gebaute VertexCore-JAR für beide Runtime-Endpunkte,
-- lädt ausschließlich den explizit gepinnten Paper-Stand über den offiziellen PaperMC-Fill-Service,
+- baut zuerst den aktuellen PR-Head mit `mvn -B -ntp verify`,
+- lädt ausschließlich den für den Matrixeintrag explizit gepinnten Paper-Stand über den offiziellen PaperMC-Fill-Service,
 - verwendet das gerade gebaute `target/vertexCore-1.1.0-SNAPSHOT.jar`,
 - startet eine frische temporäre Runtime unter `target/runtime-smoke`,
 - wartet fail-closed auf den Paper-Ready-Marker und `VertexCore enabled.`,
@@ -49,6 +56,8 @@ Der Harness:
 - behandelt Disable-/Lifecycle-Exceptions als Fehler.
 
 Der Smoke benötigt Netzwerkzugriff ausschließlich zum offiziellen PaperMC-Download-Service und erzeugt keine dauerhaften externen Zustände.
+
+Sobald fachliche Runtime-Smokes existieren, werden zusätzlich repräsentative Wege für Config, Commands und Persistenz geprüft.
 
 ## Datenbank-/Persistenzänderungen
 
@@ -79,14 +88,14 @@ Der Consumer-Check:
 - schlägt fail-closed fehl, sobald eine von NexusVault verwendete VertexCore-Signatur nicht mehr source-kompatibel ist,
 - schreibt weder in das NexusVault-Repository noch in externe dauerhafte Zustände.
 
-Aktueller Snapshot:
+Aktueller Consumer-Snapshot:
 
 ```text
 Tebrox-Development/NexusVault dev
 412becf44e6de104cfb0804f7735ff012516c0cb
 ```
 
-Der Snapshot wurde für die Gate-Pflege ausschließlich read-only über GitHub gelesen. Wenn sich NexusVault-`dev` oder dessen VertexCore-Nutzung ändert, muss der Contract gegen den dann aktuellen `dev`-SHA read-only aktualisiert werden.
+Der Snapshot wurde für die Gate-Pflege ausschließlich read-only über GitHub gelesen. Wenn sich NexusVault-`dev` oder dessen VertexCore-Nutzung ändert, muss der Contract gegen den dann aktuellen `dev`-SHA read-only aktualisiert werden. Das Gate ersetzt bewusst keinen späteren NexusVault-Paper-/BentoBox-Migrationslauf und verändert NexusVault nicht.
 
 Bei relevanten API-Änderungen muss der PR zusätzlich dokumentieren:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,44 +14,34 @@ Der Build muss auf der für den jeweiligen Scope festgelegten Java-Toolchain lau
 
 ## Plattform-Kompatibilität
 
-VertexCore 1.1.x soll mit einem einzigen Artefakt einen breiteren Paper-Bereich abdecken. Der Build-Contract ist deshalb:
+VertexCore 1.1.x wird mit Java-21-Bytecode gebaut und gegen die minimale unterstützte Paper-API 1.21.4 kompiliert. Derselbe VertexCore-Stand wird an beiden Endpunkten des unterstützten Bereichs als Runtime-Smoke geprüft:
 
-```text
-Java-Bytecode: 21
-Compile API:   Paper 1.21.4
-Runtime-Gates: Paper 1.21.4 / Java 21 und Paper 26.2 / Java 25
-```
-
-Damit gilt Java 21 als minimale VertexCore-Runtime. Paper-Versionen ab 26.1 benötigen unabhängig davon serverseitig Java 25.
-
-Verbindliche Gates:
-
-1. Maven-Build und Tests auf Java 21 erfolgreich.
-2. Kompilierung gegen die minimale unterstützte Paper API 1.21.4 erfolgreich.
-3. VertexCore-JAR lässt sich auf Paper 1.21.4 mit Java 21 laden und sauber herunterfahren.
-4. Dasselbe JAR lässt sich auf Paper 26.2 mit Java 25 laden und sauber herunterfahren.
-5. der aus dem aktuellen NexusVault-`dev` abgeleitete Consumer-Contract kompiliert und testet erfolgreich auf Java 21 gegen den geprüften VertexCore-Stand.
-
-Zwischenversionen innerhalb des unterstützten Bereichs dürfen keine neueren Paper-APIs voraussetzen als die Compile-Baseline. Die beiden Runtime-Endpunkte bilden das verbindliche CI-Gate; zusätzliche Zwischenstände können bei Bedarf ergänzt werden.
+1. Maven-Build mit Java 21 erfolgreich.
+2. Kompilierung mit `--release 21` gegen Paper API 1.21.4 erfolgreich.
+3. vorhandene Unit-/Regressionstests erfolgreich.
+4. VertexCore-JAR lässt sich auf Paper 1.21.4 mit Java 21 laden.
+5. VertexCore-JAR lässt sich auf Paper 26.2 mit Java 25 laden.
+6. beide Server erreichen einen eindeutig erkennbaren erfolgreichen Startup-Zustand ohne VertexCore-Enable-Fehler.
+7. kontrollierter Shutdown endet auf beiden Runtime-Endpunkten ohne VertexCore-Lifecycle-Fehler.
+8. der aus dem aktuellen NexusVault-`dev` abgeleitete Consumer-Contract kompiliert und testet unter Java 21 erfolgreich gegen den geprüften VertexCore-Stand.
 
 ## Runtime Smoke
 
 Der Runtime-Smoke ist automatisierbar und reproduzierbar und darf keine produktiven Serverdaten, Secrets oder externen Dienste benötigen.
 
-Die CI verwendet `.github/workflows/runtime-smoke.yml` und `scripts/runtime-smoke.sh`. Der Harness ist über `PAPER_VERSION` und `PAPER_BUILD` parametrierbar.
-
-Aktuell gepinnte Matrix:
+Die CI verwendet dafür `.github/workflows/runtime-smoke.yml` und `scripts/runtime-smoke.sh` und prüft die Endpunkte:
 
 ```text
-Paper 1.21.4 Build 232 -> Java 21
-Paper 26.2  Build 121 -> Java 25
+Paper 1.21.4 Build 232 / Java 21
+Paper 26.2 Build 121 / Java 25
 ```
 
-Für jeden Matrix-Eintrag wird der aktuelle PR-Head mit `mvn -B -ntp verify` gebaut. Der Harness:
+Der Harness:
 
-- lädt ausschließlich den explizit gepinnten stabilen Paper-Build über den offiziellen PaperMC-Fill-Service,
-- verwendet das gerade gebaute `target/vertexCore-<project.version>.jar`,
-- startet eine frische temporäre Runtime unter `target/runtime-smoke-<paper>-<build>`,
+- verwendet dasselbe mit `--release 21` gebaute VertexCore-JAR für beide Runtime-Endpunkte,
+- lädt ausschließlich den explizit gepinnten Paper-Stand über den offiziellen PaperMC-Fill-Service,
+- verwendet das gerade gebaute `target/vertexCore-1.1.0-SNAPSHOT.jar`,
+- startet eine frische temporäre Runtime unter `target/runtime-smoke`,
 - wartet fail-closed auf den Paper-Ready-Marker und `VertexCore enabled.`,
 - wertet typische VertexCore-Load-/Enable-Exceptions als Fehler,
 - sendet anschließend kontrolliert `stop`,
@@ -96,7 +86,7 @@ Tebrox-Development/NexusVault dev
 412becf44e6de104cfb0804f7735ff012516c0cb
 ```
 
-Der Snapshot wurde für die Gate-Pflege ausschließlich read-only über GitHub gelesen. Wenn sich NexusVault-`dev` oder dessen VertexCore-Nutzung ändert, muss der Contract gegen den dann aktuellen `dev`-SHA read-only aktualisiert werden. Das Gate ersetzt bewusst keinen späteren NexusVault-Paper-/BentoBox-Migrationslauf und verändert NexusVault nicht.
+Der Snapshot wurde für die Gate-Pflege ausschließlich read-only über GitHub gelesen. Wenn sich NexusVault-`dev` oder dessen VertexCore-Nutzung ändert, muss der Contract gegen den dann aktuellen `dev`-SHA read-only aktualisiert werden.
 
 Bei relevanten API-Änderungen muss der PR zusätzlich dokumentieren:
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <name>vertexCore</name>
 
     <properties>
-        <java.version>25</java.version>
-        <paper.version>26.2.build.121-stable</paper.version>
+        <java.version>21</java.version>
+        <paper.version>1.21.4-R0.1-SNAPSHOT</paper.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/scripts/runtime-smoke.sh
+++ b/scripts/runtime-smoke.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PAPER_VERSION="26.2"
-PAPER_BUILD="121"
+PAPER_VERSION="${PAPER_VERSION:-26.2}"
+PAPER_BUILD="${PAPER_BUILD:-121}"
 USER_AGENT="VertexCore-runtime-smoke/1.0 (https://github.com/Tebrox-Development/VertexCore)"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-RUNTIME_DIR="${ROOT_DIR}/target/runtime-smoke"
+RUNTIME_DIR="${ROOT_DIR}/target/runtime-smoke-${PAPER_VERSION}-${PAPER_BUILD}"
 SERVER_DIR="${RUNTIME_DIR}/server"
 LOG_FILE="${SERVER_DIR}/logs/latest.log"
 BUILD_JSON="${RUNTIME_DIR}/paper-builds.json"
-PLUGIN_JAR="${ROOT_DIR}/target/vertexCore-1.1.0-SNAPSHOT.jar"
+PROJECT_VERSION="$(mvn -B -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)"
+PLUGIN_JAR="${ROOT_DIR}/target/vertexCore-${PROJECT_VERSION}.jar"
 
 rm -rf "${RUNTIME_DIR}"
 mkdir -p "${SERVER_DIR}/plugins"
@@ -88,7 +89,7 @@ for _ in $(seq 1 120); do
 done
 
 if [[ "${READY}" -ne 1 ]]; then
-  echo "Timed out waiting for Paper 26.2 and VertexCore to become ready" >&2
+  echo "Timed out waiting for Paper ${PAPER_VERSION} build ${PAPER_BUILD} and VertexCore to become ready" >&2
   cat "${SERVER_DIR}/server-console.log" >&2 || true
   exit 1
 fi


### PR DESCRIPTION
Arbeitsstatus: READY FOR REVIEW
Worker-ID: vertexcore-compat-20260903-1840
Issue: #52
Branch: `infra/52-java21-paper-compat`
Basis: `development`
Base-SHA: `76a3ef6aac071c4266ea5838dc7cd15b54c02a33`
Finaler Head-SHA: `44f570e8b5380395db97c999bf4ba31dad751851`

## Ziel
VertexCore 1.1.x mit einem einzigen JAR auf Java 21+ und Paper 1.21.4 bis 26.2 absichern.

## Geändert
- Maven-Bytecodeziel auf Java 21 (`--release 21`) gesetzt.
- Compile-Baseline auf Paper API 1.21.4 gesetzt.
- normale CI auf Java 21 umgestellt.
- Runtime-Smoke auf eine reproduzierbare Endpunkt-Matrix erweitert:
  - Paper 1.21.4 Build 232 / Java 21
  - Paper 26.2 Build 121 / Java 25
- Runtime-Harness für Paper-Version/Build parametrierbar gemacht.
- NexusVault-Consumer-Contract unter Java 21 ausgeführt; NexusVault selbst bleibt unverändert.
- `docs/TESTING.md` auf den neuen Kompatibilitätsvertrag aktualisiert.
- teure Gates klassifizieren Änderungen und laufen bei reinen Doku-Commits nicht mehr unnötig; vollständige relevante Gates bleiben bei Review-/manuellen Läufen möglich.

## Verifiziert auf finalem Head
- CI / Java 21 Maven Verify: grün
- Paper Runtime Compatibility: grün
- NexusVault Consumer Compatibility: grün
- CodeQL: grün

## Ergebnis
VertexCore 1.1.x ist mit Java-21-Bytecode gebaut und für die geprüften Runtime-Endpunkte Paper 1.21.4/Java 21 und Paper 26.2/Java 25 abgesichert. NexusVault wurde nicht verändert.

## Nicht-Ziel
- keine NexusVault-Codeänderung
- keine öffentliche VertexCore-API-Änderung
- keine Persistenz-/Konfigurationsformatänderung
- keine neuen Features