### PR TITLE
CI: verifizierten Stable-Release-Workflow hinzufügen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,204 @@
+name: Stable Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Stable version to build and release (for example 1.1.0)
+        required: true
+        default: '1.1.0'
+        type: string
+      source_ref:
+        description: Source branch, tag or commit to release
+        required: true
+        default: development
+        type: string
+      draft:
+        description: Create the GitHub release as a draft
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: stable-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Verify and build stable release
+    runs-on: [self-hosted, Linux, X64, vertexcore]
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+
+      - name: Capture immutable source revision
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET_SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="${TARGET_SHA:0:8}"
+          echo "target_sha=${TARGET_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "short_sha=${SHORT_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "Releasing source ${TARGET_SHA}"
+
+      - name: Set up Java 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Prepare stable project version
+        id: version
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release version: ${RELEASE_VERSION}" >&2
+            exit 1
+          fi
+
+          CURRENT_VERSION="$(mvn -B -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          EXPECTED_SNAPSHOT="${RELEASE_VERSION}-SNAPSHOT"
+
+          if [[ "${CURRENT_VERSION}" != "${EXPECTED_SNAPSHOT}" && "${CURRENT_VERSION}" != "${RELEASE_VERSION}" ]]; then
+            echo "Source version ${CURRENT_VERSION} does not match ${EXPECTED_SNAPSHOT} or ${RELEASE_VERSION}" >&2
+            exit 1
+          fi
+
+          if [[ "${CURRENT_VERSION}" != "${RELEASE_VERSION}" ]]; then
+            python3 - "${CURRENT_VERSION}" "${RELEASE_VERSION}" <<'PY'
+          from pathlib import Path
+          import sys
+
+          old, new = sys.argv[1], sys.argv[2]
+          path = Path('pom.xml')
+          text = path.read_text(encoding='utf-8')
+          needle = f'<version>{old}</version>'
+          if needle not in text:
+              raise SystemExit(f'Project version {old} not found in pom.xml')
+          path.write_text(text.replace(needle, f'<version>{new}</version>', 1), encoding='utf-8')
+          PY
+          fi
+
+          EFFECTIVE_VERSION="$(mvn -B -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          if [[ "${EFFECTIVE_VERSION}" != "${RELEASE_VERSION}" ]]; then
+            echo "Failed to prepare stable version: ${EFFECTIVE_VERSION}" >&2
+            exit 1
+          fi
+
+          echo "version=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Maven verify on Java 21
+        run: mvn -B -ntp verify
+
+      - name: NexusVault consumer compatibility on Java 21
+        run: bash scripts/nexusvault-consumer-gate.sh
+
+      - name: Runtime smoke — Paper 1.21.4 / Java 21
+        env:
+          PAPER_VERSION: '1.21.4'
+          PAPER_BUILD: '232'
+        run: bash scripts/runtime-smoke.sh
+
+      - name: Set up Java 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Runtime smoke — Paper 26.2 / Java 25
+        env:
+          PAPER_VERSION: '26.2'
+          PAPER_BUILD: '121'
+        run: bash scripts/runtime-smoke.sh
+
+      - name: Prepare release artifact
+        id: artifact
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          SOURCE_JAR="target/vertexCore-${RELEASE_VERSION}.jar"
+          ASSET_NAME="vertexCore-${RELEASE_VERSION}.jar"
+          CHECKSUM_NAME="${ASSET_NAME}.sha256"
+
+          test -f "${SOURCE_JAR}"
+          cp "${SOURCE_JAR}" "${ASSET_NAME}"
+          sha256sum "${ASSET_NAME}" > "${CHECKSUM_NAME}"
+          SHA256="$(cut -d ' ' -f1 "${CHECKSUM_NAME}")"
+
+          echo "asset_name=${ASSET_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "checksum_name=${CHECKSUM_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "sha256=${SHA256}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create GitHub release
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ steps.source.outputs.target_sha }}
+          SHORT_SHA: ${{ steps.source.outputs.short_sha }}
+          ASSET_NAME: ${{ steps.artifact.outputs.asset_name }}
+          CHECKSUM_NAME: ${{ steps.artifact.outputs.checksum_name }}
+          SHA256: ${{ steps.artifact.outputs.sha256 }}
+          DRAFT: ${{ inputs.draft }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const body = [
+              `Stable VertexCore ${process.env.VERSION} release artifact built from development source ${process.env.TARGET_SHA}.`,
+              '',
+              '### Verified before release',
+              '',
+              '- Maven verify / Java 21',
+              '- NexusVault consumer compatibility / Java 21',
+              '- Paper 1.21.4 build 232 / Java 21 runtime smoke',
+              '- Paper 26.2 build 121 / Java 25 runtime smoke',
+              '',
+              `SHA256: \`${process.env.SHA256}\``,
+            ].join('\n');
+
+            const { data: release } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: process.env.TAG,
+              target_commitish: process.env.TARGET_SHA,
+              name: `VertexCore ${process.env.VERSION}`,
+              body,
+              draft: process.env.DRAFT === 'true',
+              prerelease: false,
+            });
+
+            for (const assetName of [process.env.ASSET_NAME, process.env.CHECKSUM_NAME]) {
+              const data = fs.readFileSync(assetName);
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.id,
+                name: assetName,
+                data,
+                headers: {
+                  'content-type': assetName.endsWith('.sha256') ? 'text/plain' : 'application/java-archive',
+                  'content-length': data.length,
+                },
+              });
+            }


### PR DESCRIPTION
## Ziel

Fügt einen manuellen Stable-Release-Workflow auf `master` hinzu, der ein Release-Artefakt aus einem exakt aufgelösten Source-Ref erzeugt.

## Ablauf

- `release_version` (Default `1.1.0`) und `source_ref` (Default `development`) als manuelle Inputs
- Source-Commit wird zu Beginn auf eine feste SHA aufgelöst
- Projektversion wird nur im Runner-Arbeitsverzeichnis von `x.y.z-SNAPSHOT` auf `x.y.z` gesetzt
- Maven Verify auf Java 21
- NexusVault Consumer Compatibility auf Java 21
- Runtime-Smoke auf Paper 1.21.4 Build 232 / Java 21
- Runtime-Smoke auf Paper 26.2 Build 121 / Java 25
- exakt dasselbe gebaute JAR wird als `vertexCore-<version>.jar` verwendet
- SHA256-Datei wird erzeugt und mit hochgeladen
- GitHub Release `v<version>` wird erstellt
- standardmäßig als **Draft**, kann beim manuellen Start explizit veröffentlicht werden

## Sicherheit

Der Workflow bricht ab, wenn die Source-Version nicht zur gewünschten Release-Version passt. `development` selbst wird nicht verändert und es erfolgt kein automatischer Merge.