### PR TITLE
Docs: JitPack-Koordinaten für 1.1.0 korrigieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.github.Tebrox:VertexCore:v1.0.0")
+    compileOnly("com.github.Tebrox-Development:VertexCore:v1.1.0")
 }
 ```
 
@@ -99,9 +99,9 @@ dependencies {
 </repository>
 
 <dependency>
-    <groupId>com.github.Tebrox</groupId>
+    <groupId>com.github.Tebrox-Development</groupId>
     <artifactId>VertexCore</artifactId>
-    <version>v1.0.0</version>
+    <version>v1.1.0</version>
     <scope>provided</scope>
 </dependency>
 ```


### PR DESCRIPTION
## Ziel

Korrigiert die Developer-Usage-Beispiele in der README für den Stable-Release 1.1.0.

## Änderungen

- JitPack Group/Repository von `Tebrox` auf `Tebrox-Development` aktualisiert
- Gradle-Version auf `v1.1.0` aktualisiert
- Maven-Version auf `v1.1.0` aktualisiert

Nur Dokumentation, keine Codeänderungen.